### PR TITLE
Improve crawl by blocking non-threatened external resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,17 @@ This includes all sub domains like abc.collection.litme.com.ua, handles http:// 
     collection: "collection-litme-com-ua"
     workers: 16
     saveState: always
+    blockRules:
+      - url: google-analytics.com
+      - url: youtube.com/embed/
+      - url: yandex.ru
+      - url: mycounter.ua
+      - url: googletagmanager.com
+      - url: facebook.(com|net)
     seeds:
         - url: http://collection.litme.com.ua/
           scopeType: "domain"
-    
+
 ## Excluding trouble
 
 If you notice that a crawl is collecting duplicate links due to parameters, like 


### PR DESCRIPTION
Some external resources, such as YouTube embeds or analytics trackers, should not need to be recorded because they are not currently threatened by the war. Explicitly blocking the recording of these resources speeds up the crawl significantly, because the worker doesn't have to wait until the page times out to be able to move on to the next page (also some of these trackers start blocking on their end if they think that you are a bot, which only slows things down the more). In the case of YouTube embeds, it also reduces the size of the resulting collection archives significantly. The markup for these items is still preserved and can be replayed at a later time. The list of `blockRules` provided in this commit is likely incomplete. I imagine others will find more resources to add to the list.

I am suggesting that the improvement is so significant that this approach should be the default for the SUCHO project.